### PR TITLE
bump pyjavaproperties version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     install_requires = [
         'boto3==1.4.4',
         'pantsbuild.pants>=1.16.0',
-        'pyjavaproperties==0.6',
+        'pyjavaproperties==0.7',
         'six>=1.9.0,<2'
     ],
     package_dir = {


### PR DESCRIPTION
Version 0.6 is not forwards compatible with python3. 0.7 is